### PR TITLE
Use parameters in OpenAPI server URL

### DIFF
--- a/src/openapi/TiMessengerContactManagement.yaml
+++ b/src/openapi/TiMessengerContactManagement.yaml
@@ -36,7 +36,20 @@ externalDocs:
   url: https://github.com/gematik/api-ti-messenger
 
 servers:
-  - url: https://localhost/tim-contact-mgmt/v1.0/
+  - url: '{protocol}://{host}:{port}/{api}/'
+    variables:
+      protocol:
+        enum:
+          - http
+          - https
+        default: https
+      host:
+        default: 'localhost'
+      port:
+        default: '443'
+      api:
+        default: 'tim-contact-mgmt/v1.0'
+
 tags:
   - name: info
     description: This operation returns meta data about this interface and the status of available resources

--- a/src/openapi/TiMessengerTestTreiber.yaml
+++ b/src/openapi/TiMessengerTestTreiber.yaml
@@ -16,7 +16,19 @@ externalDocs:
   url: https://github.com/gematik/api-ti-messenger
 
 servers:
-  - url: https://localhost/ti-messenger-testdriver/
+  - url: '{protocol}://{host}:{port}/{api}/'
+    variables:
+      protocol:
+        enum:
+          - http
+          - https
+        default: https
+      host:
+        default: 'localhost'
+      port:
+        default: '443'
+      api:
+        default: 'ti-messenger-testdriver'
 
 tags:
   - name: info


### PR DESCRIPTION
This allows to select the actual server in the generated OpenAPI doc:
![image](https://github.com/gematik/api-ti-messenger/assets/37705355/14342784-92c4-4e7a-ba93-ee59d0e6a001)
